### PR TITLE
fix: ensure all HTTP methods send extra headers

### DIFF
--- a/datalakes.go
+++ b/datalakes.go
@@ -65,7 +65,7 @@ func (c *Client) CreateDatalake(req CreateDatalakeRequest) (*Datalake, error) {
 	if err != nil {
 		return nil, err
 	}
-	httpReq.Header.Set("Authorization", headers["Authorization"])
+	for k, v := range headers { httpReq.Header.Set(k, v) }
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(httpReq)
@@ -214,7 +214,7 @@ func (c *Client) UpdateDatalake(id string, req UpdateDatalakeRequest) (*Datalake
 	if err != nil {
 		return nil, err
 	}
-	httpReq.Header.Set("Authorization", headers["Authorization"])
+	for k, v := range headers { httpReq.Header.Set(k, v) }
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(httpReq)

--- a/hosting_environments.go
+++ b/hosting_environments.go
@@ -111,7 +111,7 @@ func (c *Client) CreateHostingEnvironment(req CreateHostingEnvironmentRequest) (
 	if err != nil {
 		return nil, err
 	}
-	httpReq.Header.Set("Authorization", headers["Authorization"])
+	for k, v := range headers { httpReq.Header.Set(k, v) }
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(httpReq)
@@ -223,7 +223,7 @@ func (c *Client) UpdateHostingEnvironment(id string, req UpdateHostingEnvironmen
 	if err != nil {
 		return nil, err
 	}
-	httpReq.Header.Set("Authorization", headers["Authorization"])
+	for k, v := range headers { httpReq.Header.Set(k, v) }
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(httpReq)
@@ -325,7 +325,9 @@ func (c *Client) PostConnection(id string, req *PostConnectionRequest) error {
 	if err != nil {
 		return err
 	}
-	httpReq.Header.Set("Authorization", headers["Authorization"])
+	for k, v := range headers {
+		httpReq.Header.Set(k, v)
+	}
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(httpReq)

--- a/source_app_datalake_links.go
+++ b/source_app_datalake_links.go
@@ -60,7 +60,7 @@ func (c *Client) CreateSourceAppDatalakeLink(req CreateSourceAppDatalakeLinkRequ
 	if err != nil {
 		return nil, err
 	}
-	httpReq.Header.Set("Authorization", headers["Authorization"])
+	for k, v := range headers { httpReq.Header.Set(k, v) }
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(httpReq)

--- a/source_apps.go
+++ b/source_apps.go
@@ -61,7 +61,7 @@ func (c *Client) CreateSourceApp(req CreateSourceAppRequest) (*SourceApp, error)
 	if err != nil {
 		return nil, err
 	}
-	httpReq.Header.Set("Authorization", headers["Authorization"])
+	for k, v := range headers { httpReq.Header.Set(k, v) }
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(httpReq)
@@ -211,7 +211,7 @@ func (c *Client) UpdateSourceApp(id string, req UpdateSourceAppRequest) (*Source
 	if err != nil {
 		return nil, err
 	}
-	httpReq.Header.Set("Authorization", headers["Authorization"])
+	for k, v := range headers { httpReq.Header.Set(k, v) }
 	httpReq.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(httpReq)


### PR DESCRIPTION
POST and PATCH methods were only sending Authorization header, missing extra headers like x-vercel-protection-bypass needed for preview environments.